### PR TITLE
Adding URL in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redis / Node.js Crash Course
 
-This is the source code repository for the Node.js Redis Crash Course.  It's designed to be used with the workbooks and videos that make up the course.
+This is the source code repository for the [Node.js Redis Crash Course](https://developer.redis.com/develop/node/node-crash-course).  It's designed to be used with the workbooks and videos that make up the course.
 
 If you are looking for solutions to the coding exercises that form an optional part of the course, check out the `solutions` branch.
 


### PR DESCRIPTION
Links the text 'Node.js Redis Crash Course' to the following URL:
https://developer.redis.com/develop/node/node-crash-course
Please see issue #4 for further information.