### PR TITLE
fix: updated docker-compose.yml to use redis-stack container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,11 @@ version: "3.9"
 services:
   redis:
     container_name: rediscrashcourse
-    image: "redislabs/redismod"
+    image: "redis/redis-stack"
     ports:
       - 6379:6379
     volumes:
       - ./redisdata:/data
-    entrypoint:
-      redis-server
-        --loadmodule /usr/lib/redis/modules/redisearch.so
-        --loadmodule /usr/lib/redis/modules/rejson.so
-        --loadmodule /usr/lib/redis/modules/redisbloom.so
-        --appendonly yes
     deploy:
       replicas: 1
       restart_policy:


### PR DESCRIPTION
Closes: #12 
Changed `redismod` container image with `redis/redis-stack` container image.
And also remove the `entrypoint` from the `docker-compose.yml`.
Application runs fine after the changes, gives the same output as before.

My twitter handle is: mohdimran_25. Thanks!